### PR TITLE
Dont require cmake 3.2 when 2.8 works fine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 2.8)
 
 #*****************************************************************#
 # Create the master machine .js file. This file will


### PR DESCRIPTION
The unnecessary check was causing some build issues in our development environment.